### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,6 @@
 **/Makefile.* @cloudposse-terraform-components/engineering
 
 # Cloud Posse must review any changes to tflint configuration and pre-commit config
-.tflint.hcl             @cloudposse-terraform-components/engineering
 .pre-commit-config.yaml @cloudposse-terraform-components/engineering
 
 # Cloud Posse Admins must review all changes to CODEOWNERS, github configuration or the mergify configuration


### PR DESCRIPTION
## what
* Do not require codeowners for tflint config

## why
* Tflint does not critical for workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated code ownership rules by removing the assignment for `.tflint.hcl` file. All other ownership assignments remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->