### PR TITLE
feat: Deploy Keys as Optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ github/
 *.ovpn
 
 *.zip
+account-map/

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,3 +1,9 @@
+## `argocd-github-repo` Component PR [#17](https://github.com/cloudposse-terraform-components/aws-argocd-github-repo/pull/17)
+
+Corrected the spelling of "succeded" to "succeeded" in the `on-deploy-succeded` notification. As a result, both components (`argocd-github-repo` and `eks/argocd`) need to be updated to make this change.
+
+See the [PR for eks/argocd](https://github.com/cloudposse-terraform-components/aws-eks-argocd/pull/16)
+
 ## Components PR [#851](https://github.com/cloudposse/terraform-aws-components/pull/851)
 
 This is a bug fix and feature enhancement update. There are few actions necessary to upgrade.
@@ -25,7 +31,7 @@ components:
   - `on-deploy-started`
     - `app-repo-github-commit-status`
     - `argocd-repo-github-commit-status`
-  - `on-deploy-succeeded`
+  - `on-deploy-succeded`
     - `app-repo-github-commit-status`
     - `argocd-repo-github-commit-status`
   - `on-deploy-failed`

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,9 +1,3 @@
-## `argocd-github-repo` Component PR [#17](https://github.com/cloudposse-terraform-components/aws-argocd-github-repo/pull/17)
-
-Corrected the spelling of "succeded" to "succeeded" in the `on-deploy-succeded` notification. As a result, both components (`argocd-github-repo` and `eks/argocd`) need to be updated to make this change.
-
-See the [PR for eks/argocd](https://github.com/cloudposse-terraform-components/aws-eks-argocd/pull/16)
-
 ## Components PR [#851](https://github.com/cloudposse/terraform-aws-components/pull/851)
 
 This is a bug fix and feature enhancement update. There are few actions necessary to upgrade.
@@ -31,7 +25,7 @@ components:
   - `on-deploy-started`
     - `app-repo-github-commit-status`
     - `argocd-repo-github-commit-status`
-  - `on-deploy-succeded`
+  - `on-deploy-succeeded`
     - `app-repo-github-commit-status`
     - `argocd-repo-github-commit-status`
   - `on-deploy-failed`

--- a/src/README.md
+++ b/src/README.md
@@ -6,9 +6,10 @@ tags:
   - provider/github
 ---
 
-# Component: `argocd-github-repo`
+# Component: `argocd-repo`
 
 This component is responsible for creating and managing an ArgoCD desired state repository.
+
 ## Usage
 
 **Stack Level**: Regional
@@ -83,10 +84,7 @@ $ terraform import -var "import_profile_name=eg-mgmt-gbl-corp-admin" -var-file="
 ```
 
 <!-- prettier-ignore-start -->
-<!-- prettier-ignore-end -->
-
-
-<!-- markdownlint-disable -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
@@ -109,7 +107,7 @@ $ terraform import -var "import_profile_name=eg-mgmt-gbl-corp-admin" -var-file="
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
-| <a name="module_store_write"></a> [store\_write](#module\_store\_write) | cloudposse/ssm-parameter-store/aws | 0.13.0 |
+| <a name="module_store_write"></a> [store\_write](#module\_store\_write) | cloudposse/ssm-parameter-store/aws | 0.11.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
@@ -142,6 +140,7 @@ $ terraform import -var "import_profile_name=eg-mgmt-gbl-corp-admin" -var-file="
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
 | <a name="input_create_repo"></a> [create\_repo](#input\_create\_repo) | Whether or not to create the repository or use an existing one | `bool` | `true` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_deploy_keys_enabled"></a> [deploy\_keys\_enabled](#input\_deploy\_keys\_enabled) | Enable GitHub deploy keys for the repository. These are used for Argo CD application syncing. Alternatively, you can use a GitHub App to access this desired state repository. | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | The description of the repository | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>   format = string<br/>   labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
@@ -190,19 +189,15 @@ $ terraform import -var "import_profile_name=eg-mgmt-gbl-corp-admin" -var-file="
 | <a name="output_repository_default_branch"></a> [repository\_default\_branch](#output\_repository\_default\_branch) | Repository default branch |
 | <a name="output_repository_description"></a> [repository\_description](#output\_repository\_description) | Repository description |
 | <a name="output_repository_git_clone_url"></a> [repository\_git\_clone\_url](#output\_repository\_git\_clone\_url) | Repository git clone URL |
+| <a name="output_repository_http_clone_url"></a> [repository\_http\_clone\_url](#output\_repository\_http\_clone\_url) | Repository HTTP clone URL |
 | <a name="output_repository_ssh_clone_url"></a> [repository\_ssh\_clone\_url](#output\_repository\_ssh\_clone\_url) | Repository SSH clone URL |
 | <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | Repository URL |
-<!-- markdownlint-restore -->
-
-
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- prettier-ignore-end -->
 
 ## References
 
+- [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/main/modules/argocd-repo) -
+  Cloud Posse's upstream component
 
-- [cloudposse-terraform-components](https://github.com/orgs/cloudposse-terraform-components/repositories) - Cloud Posse's upstream component
-
-
-
-
-[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-argocd-github-repo&utm_content=)
-
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/src/README.md
+++ b/src/README.md
@@ -6,10 +6,9 @@ tags:
   - provider/github
 ---
 
-# Component: `argocd-repo`
+# Component: `argocd-github-repo`
 
 This component is responsible for creating and managing an ArgoCD desired state repository.
-
 ## Usage
 
 **Stack Level**: Regional
@@ -84,7 +83,10 @@ $ terraform import -var "import_profile_name=eg-mgmt-gbl-corp-admin" -var-file="
 ```
 
 <!-- prettier-ignore-start -->
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- prettier-ignore-end -->
+
+
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -107,7 +109,7 @@ $ terraform import -var "import_profile_name=eg-mgmt-gbl-corp-admin" -var-file="
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
-| <a name="module_store_write"></a> [store\_write](#module\_store\_write) | cloudposse/ssm-parameter-store/aws | 0.11.0 |
+| <a name="module_store_write"></a> [store\_write](#module\_store\_write) | cloudposse/ssm-parameter-store/aws | 0.13.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
@@ -140,7 +142,6 @@ $ terraform import -var "import_profile_name=eg-mgmt-gbl-corp-admin" -var-file="
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
 | <a name="input_create_repo"></a> [create\_repo](#input\_create\_repo) | Whether or not to create the repository or use an existing one | `bool` | `true` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| <a name="input_deploy_keys_enabled"></a> [deploy\_keys\_enabled](#input\_deploy\_keys\_enabled) | Enable GitHub deploy keys for the repository. These are used for Argo CD application syncing. Alternatively, you can use a GitHub App to access this desired state repository. | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | The description of the repository | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>   format = string<br/>   labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
@@ -189,15 +190,18 @@ $ terraform import -var "import_profile_name=eg-mgmt-gbl-corp-admin" -var-file="
 | <a name="output_repository_default_branch"></a> [repository\_default\_branch](#output\_repository\_default\_branch) | Repository default branch |
 | <a name="output_repository_description"></a> [repository\_description](#output\_repository\_description) | Repository description |
 | <a name="output_repository_git_clone_url"></a> [repository\_git\_clone\_url](#output\_repository\_git\_clone\_url) | Repository git clone URL |
-| <a name="output_repository_http_clone_url"></a> [repository\_http\_clone\_url](#output\_repository\_http\_clone\_url) | Repository HTTP clone URL |
 | <a name="output_repository_ssh_clone_url"></a> [repository\_ssh\_clone\_url](#output\_repository\_ssh\_clone\_url) | Repository SSH clone URL |
 | <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | Repository URL |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-<!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
+
+
 
 ## References
 
-- [cloudposse/terraform-aws-components](https://github.com/cloudposse/terraform-aws-components/tree/main/modules/argocd-repo) -
-  Cloud Posse's upstream component
 
-[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)
+- [cloudposse-terraform-components](https://github.com/orgs/cloudposse-terraform-components/repositories) - Cloud Posse's upstream component
+
+
+
+
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-argocd-github-repo&utm_content=)

--- a/src/applicationset.tf
+++ b/src/applicationset.tf
@@ -15,7 +15,7 @@ resource "github_repository_file" "application_set" {
     ignore-differences          = each.value.ignore-differences
     name                        = module.this.namespace
     namespace                   = local.manifest_kubernetes_namespace
-    ssh_url                     = local.github_repository.ssh_clone_url
+    url                         = local.deploy_keys_enabled ? local.github_repository.ssh_clone_url : local.github_repository.http_clone_url
     notifications               = local.github_notifications
     slack_notifications_channel = var.slack_notifications_channel
   })

--- a/src/main.tf
+++ b/src/main.tf
@@ -15,9 +15,9 @@ locals {
 
   manifest_kubernetes_namespace = var.manifest_kubernetes_namespace
 
-  team_slugs = toset(compact([
+  team_slugs = local.enabled ? toset(compact([
     for permission in var.permissions : lookup(permission, "team_slug", null)
-  ]))
+  ])) : []
 
   team_ids = [
     for team in data.github_team.default : team.id

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,5 +1,6 @@
 locals {
-  enabled = module.this.enabled
+  enabled             = module.this.enabled
+  deploy_keys_enabled = local.enabled && var.deploy_keys_enabled
 
   environments = local.enabled ? {
     for env in var.environments :
@@ -14,9 +15,9 @@ locals {
 
   manifest_kubernetes_namespace = var.manifest_kubernetes_namespace
 
-  team_slugs = local.enabled ? toset(compact([
+  team_slugs = toset(compact([
     for permission in var.permissions : lookup(permission, "team_slug", null)
-  ])) : []
+  ]))
 
   team_ids = [
     for team in data.github_team.default : team.id
@@ -118,14 +119,14 @@ resource "github_team_repository" "default" {
 }
 
 resource "tls_private_key" "default" {
-  for_each = local.environments
+  for_each = local.deploy_keys_enabled ? local.environments : {}
 
   algorithm = "RSA"
   rsa_bits  = "2048"
 }
 
 resource "github_repository_deploy_key" "default" {
-  for_each = local.environments
+  for_each = local.deploy_keys_enabled ? local.environments : {}
 
   title      = "Deploy key for ArgoCD environment: ${each.key} (${local.github_repository.default_branch} branch)"
   repository = local.github_repository.name

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -15,25 +15,30 @@ output "repository" {
 
 output "repository_description" {
   description = "Repository description"
-  value       = local.enabled ? local.github_repository.description : null
+  value       = local.github_repository.description
 }
 
 output "repository_default_branch" {
   description = "Repository default branch"
-  value       = local.enabled ? local.github_repository.default_branch : null
+  value       = local.github_repository.default_branch
 }
 
 output "repository_url" {
   description = "Repository URL"
-  value       = local.enabled ? local.github_repository.html_url : null
+  value       = local.github_repository.html_url
 }
 
 output "repository_git_clone_url" {
   description = "Repository git clone URL"
-  value       = local.enabled ? local.github_repository.git_clone_url : null
+  value       = local.github_repository.git_clone_url
 }
 
 output "repository_ssh_clone_url" {
   description = "Repository SSH clone URL"
-  value       = local.enabled ? local.github_repository.ssh_clone_url : null
+  value       = local.github_repository.ssh_clone_url
+}
+
+output "repository_http_clone_url" {
+  description = "Repository HTTP clone URL"
+  value       = local.github_repository.http_clone_url
 }

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -1,6 +1,6 @@
 output "deploy_keys_ssm_paths" {
   description = "SSM Parameter Store paths for the repository's deploy keys"
-  value       = module.store_write.names
+  value       = local.deploy_keys_enabled ? module.store_write.names : []
 }
 
 output "deploy_keys_ssm_path_format" {
@@ -15,30 +15,30 @@ output "repository" {
 
 output "repository_description" {
   description = "Repository description"
-  value       = local.github_repository.description
+  value       = local.enabled ? local.github_repository.description : null
 }
 
 output "repository_default_branch" {
   description = "Repository default branch"
-  value       = local.github_repository.default_branch
+  value       = local.enabled ? local.github_repository.default_branch : null
 }
 
 output "repository_url" {
   description = "Repository URL"
-  value       = local.github_repository.html_url
+  value       = local.enabled ? local.github_repository.html_url : null
 }
 
 output "repository_git_clone_url" {
   description = "Repository git clone URL"
-  value       = local.github_repository.git_clone_url
+  value       = local.enabled ? local.github_repository.git_clone_url : null
 }
 
 output "repository_ssh_clone_url" {
   description = "Repository SSH clone URL"
-  value       = local.github_repository.ssh_clone_url
+  value       = local.enabled ? local.github_repository.ssh_clone_url : null
 }
 
 output "repository_http_clone_url" {
   description = "Repository HTTP clone URL"
-  value       = local.github_repository.http_clone_url
+  value       = local.enabled ? local.github_repository.http_clone_url : null
 }

--- a/src/provider-github.tf
+++ b/src/provider-github.tf
@@ -2,6 +2,8 @@ locals {
   github_token = local.enabled ? (
     var.use_local_github_credentials ? null : coalesce(var.github_token_override, data.aws_ssm_parameter.github_api_key[0].value)
   ) : ""
+
+  deploy_key_environments = local.deploy_keys_enabled ? local.environments : {}
 }
 
 data "aws_ssm_parameter" "github_api_key" {
@@ -12,9 +14,9 @@ data "aws_ssm_parameter" "github_api_key" {
 
 module "store_write" {
   source  = "cloudposse/ssm-parameter-store/aws"
-  version = "0.13.0"
+  version = "0.11.0"
 
-  parameter_write = [for k, v in local.environments :
+  parameter_write = [for k, v in local.deploy_key_environments :
     {
       name        = format(var.ssm_github_deploy_key_format, k)
       value       = tls_private_key.default[k].private_key_pem

--- a/src/templates/applicationset.yaml.tpl
+++ b/src/templates/applicationset.yaml.tpl
@@ -37,7 +37,7 @@ metadata:
 spec:
   generators:
     - git:
-        repoURL: ${ssh_url}
+        repoURL: ${url}
         revision: HEAD
         files:
           - path: ${environment}/apps/*/*/config.yaml
@@ -63,7 +63,7 @@ spec:
     spec:
       project: ${name}
       source:
-        repoURL: ${ssh_url}
+        repoURL: ${url}
         targetRevision: HEAD
         path: '{{manifests}}'
       destination:

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -209,3 +209,9 @@ variable "use_local_github_credentials" {
   description = "Use local GitHub credentials from environment variables instead of SSM"
   default     = false
 }
+
+variable "deploy_keys_enabled" {
+  type        = bool
+  description = "Enable GitHub deploy keys for the repository. These are used for Argo CD application syncing. Alternatively, you can use a GitHub App to access this desired state repository."
+  default     = true
+}


### PR DESCRIPTION
## what
- Deploy keys are optional

## why
- Optionally support using GitHub Apps for authentication rather than deploy keys

## references
- https://github.com/cloudposse-terraform-components/aws-eks-argocd/pull/42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toggle to enable/disable deploy keys; when disabled, deploy keys and related parameters/SSM paths are not created.
  * Application sources now auto-select SSH or HTTP clone URLs based on the toggle.
  * New output exposes the repository HTTP clone URL.
  * deploy_keys_ssm_paths returns an empty list when deploy keys are disabled.

* **Documentation**
  * Removed a trailing logo from the README.

* **Chores**
  * Added account-map/ to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->