### PR TITLE
chore: migrate renovate config preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "prConcurrentLimit": 5,
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
## What
- Migrate Renovate preset from `config:base` to `config:recommended`.

## Why
Renovate's Dependency Dashboard flags this repository with `Config Migration Needed`; `config:recommended` is the current replacement preset.

## Validation
- Parsed `.github/renovate.json` as JSON.
- Ran `git diff --check`.

I did not run the Atmos/Terratest suite because repository guidance notes those tests can deploy AWS resources and may incur cost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->